### PR TITLE
feat: adiciona funcionalidades de copiar, colar, recortar

### DIFF
--- a/src/components/Hotkeys.tsx
+++ b/src/components/Hotkeys.tsx
@@ -1,13 +1,17 @@
 import React from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { useReactFlow } from "reactflow";
 
 import actions from "~/core/actions";
 import useStoreEphemeral from "~/store/useStoreEphemeral";
 import useStoreMachine from "~/store/useStoreMachine";
+import useStoreFlowchart from "~/store/useStoreFlowchart";
 
 export default function (): JSX.Element {
   const { refInput } = useStoreEphemeral();
   const { machineState, executeAction } = useStoreMachine();
+  const { copyNodes, pasteNodes, cutNodes } = useStoreFlowchart();  
+  const { getNodes } = useReactFlow();
 
   for (const { actionId, hotkey, enabledStatuses } of actions) {
     useHotkeys(
@@ -27,7 +31,23 @@ export default function (): JSX.Element {
     );
   }
 
-  // useHotkeys("ctrl+a", selectAll);  // TODO: Implement selectAll
+  const getSelectedIds = () =>
+    getNodes()
+      .filter((n) => n.selected)
+      .map((n) => n.id);
 
+  useHotkeys("ctrl+c, meta+c", () => copyNodes(getSelectedIds()), {
+    preventDefault: true,
+  });
+
+  useHotkeys("ctrl+v, meta+v", () => pasteNodes(), {
+    preventDefault: true,
+  });
+
+  useHotkeys("ctrl+x, meta+x", () => cutNodes(getSelectedIds()), {
+    preventDefault: true,
+  });
+
+  // useHotkeys("ctrl+a", selectAll);  // TODO: Implement selectAll
   return <></>;
 }

--- a/src/store/useStoreFlowchart.ts
+++ b/src/store/useStoreFlowchart.ts
@@ -37,6 +37,10 @@ export interface Flowchart {
 interface StoreFlowchart {
   flowchart: Flowchart;
   savedViewport: Viewport;
+  clipboard: { nodes: Node<NodeData>[]; edges: Edge[] };
+  copyNodes: (ids: string[]) => void;
+  pasteNodes: () => void;
+  cutNodes: (ids: string[]) => void;
   clearFlowchart: () => void;
   importSimpleFlowchart: (simpleFlowchart: SimpleFlowchart) => void;
   setTitle: (title: string) => void;
@@ -88,6 +92,8 @@ const useStoreFlowchart = create<StoreFlowchart>()(
     (set, get) => ({
       flowchart: getDefaultFlowchart(),
       savedViewport: getDefaultViewport(),
+      clipboard: { nodes: [], edges: [] },
+
       clearFlowchart: () => {
         set({
           flowchart: getDefaultFlowchart(),
@@ -232,10 +238,74 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       setSavedViewport: (viewport) => set({ savedViewport: viewport }),
+
+      // ── Clipboard ────────────────────────────────────────────────────────────
+      copyNodes: (ids) => {
+        const { flowchart } = get();
+        const idSet = new Set(ids);
+        const copiedNodes = flowchart.nodes
+          .filter((n) => idSet.has(n.id))
+          .map((n) => _.cloneDeep(n));
+        const copiedEdges = flowchart.edges
+          .filter((e) => idSet.has(e.source) && idSet.has(e.target))
+          .map((e) => _.cloneDeep(e));
+        set({ clipboard: { nodes: copiedNodes, edges: copiedEdges } });
+      },
+
+      pasteNodes: () => {
+        const { flowchart, clipboard } = get();
+        if (clipboard.nodes.length === 0) return;
+
+        // Reserva IDs novos sequencialmente sem colidir entre si
+        const idMap = new Map<string, string>();
+        const tempNodes = [...flowchart.nodes];
+        clipboard.nodes.forEach((n) => {
+          const newId = getNextAvailableNodeId(tempNodes);
+          idMap.set(n.id, newId);
+          tempNodes.push({ ...n, id: newId });
+        });
+
+        const newNodes: Node<NodeData>[] = clipboard.nodes.map((n) => ({
+          ..._.cloneDeep(n),
+          id: idMap.get(n.id)!,
+          position: { x: n.position.x + 30, y: n.position.y + 30 },
+          selected: true,
+        }));
+
+        const newEdges: Edge[] = clipboard.edges
+          .filter((e) => idMap.has(e.source) && idMap.has(e.target))
+          .map((e) => ({
+            ..._.cloneDeep(e),
+            id: `${idMap.get(e.source)}-${idMap.get(e.target)}-${e.sourceHandle}`,
+            source: idMap.get(e.source)!,
+            target: idMap.get(e.target)!,
+            selected: true,
+          }));
+
+        flowchart.nodes = [
+          ...flowchart.nodes.map((n) => ({ ...n, selected: false })),
+          ...newNodes,
+        ];
+        flowchart.edges = [
+          ...flowchart.edges.map((e) => ({ ...e, selected: false })),
+          ...newEdges,
+        ];
+        set({ flowchart });
+      },
+
+      cutNodes: (ids) => {
+        const { copyNodes, deleteNode } = get();
+        copyNodes(ids);
+        ids.forEach((id) => deleteNode(id));
+      },
     }),
     {
       name: "fluxolab_flow",
       version: 8,
+      partialize: (state) => {
+        const { clipboard, ...rest } = state;
+        return rest;
+      },
     },
   ),
 );


### PR DESCRIPTION
## Implementa Copiar, Colar e Recortar blocos

### Motivação

Adiciona suporte às teclas de atalho **Ctrl+C / Ctrl+V / Ctrl+X** (e equivalentes no Mac) para os blocos do fluxograma.

---

### Arquivos modificados

#### `src/store/useStoreFlowchart.ts`

Adiciona três novos métodos ao store e um campo de estado para a área de transferência:

- **`clipboard`**: estado que armazena os nós e arestas copiados.
- **`copyNodes(ids)`**: recebe os IDs dos nós selecionados, filtra os nós e arestas correspondentes e salva uma cópia profunda (`_.cloneDeep`) no clipboard. Apenas arestas cujos dois extremos estão selecionados são copiadas.
- **`pasteNodes()`**: gera novos IDs numéricos sequenciais (respeitando o esquema já existente do projeto via `getNextAvailableNodeId`), reposiciona os nós colados com um offset de 30px para não sobrepor os originais, remapeia os IDs das arestas e insere tudo no flowchart deselecionando os nós anteriores.
- **`cutNodes(ids)`**: combina `copyNodes` + `deleteNode`, recortando os nós selecionados.

O campo `clipboard` foi excluído da persistência no `localStorage` via `partialize`, pois não faz sentido manter a área de transferência entre sessões.

#### `src/components/Hotkeys.tsx`

Adiciona três novos atalhos de teclado usando o `react-hotkeys-hook` já presente no projeto:

- **Ctrl+C / Cmd+C** → `copyNodes` com os nós atualmente selecionados
- **Ctrl+V / Cmd+V** → `pasteNodes`
- **Ctrl+X / Cmd+X** → `cutNodes` com os nós atualmente selecionados

Os IDs dos nós selecionados são obtidos via `useReactFlow().getNodes()`, que já estava disponível dentro do `ReactFlowProvider` no `App.tsx`.

---

### O que não foi alterado

- A lógica de seleção múltipla (Shift+clique e arraste) já existia e foi reaproveitada.
- O atalho Delete para exclusão já existia e não foi tocado.
- Nenhuma alteração em `Flow/index.tsx` ou `App.tsx` foi necessária.

---

### Como testar

1. Adicione um ou mais blocos ao canvas
2. Selecione um bloco (clique) ou múltiplos (Shift+clique ou arraste)
3. Pressione **Ctrl+C** — os blocos são copiados
4. Pressione **Ctrl+V** — os blocos aparecem com offset de 30px já selecionados
5. Pressione **Ctrl+X** — os blocos são removidos do canvas mas ficam no clipboard
6. Pressione **Ctrl+V** — os blocos recortados são colados