### PR TITLE
feat: adiciona Desfazer, Refazer e Selecionar Tudo

### DIFF
--- a/src/components/Hotkeys.tsx
+++ b/src/components/Hotkeys.tsx
@@ -6,11 +6,13 @@ import actions from "~/core/actions";
 import useStoreEphemeral from "~/store/useStoreEphemeral";
 import useStoreMachine from "~/store/useStoreMachine";
 import useStoreClipboard from "~/store/useStoreClipboard";
+import useStoreFlowchart from "~/store/useStoreFlowchart";
 
 export default function (): JSX.Element {
   const { refInput } = useStoreEphemeral();
   const { machineState, executeAction } = useStoreMachine();
-  const { copyNodes, pasteNodes, cutNodes } = useStoreClipboard();
+  const { copyNodes, pasteNodes, cutNodes, selectAll } = useStoreClipboard();
+  const { undo, redo } = useStoreFlowchart();
   const { getNodes } = useReactFlow();
 
   for (const { actionId, hotkey, enabledStatuses } of actions) {
@@ -48,6 +50,16 @@ export default function (): JSX.Element {
     preventDefault: true,
   });
 
-  // useHotkeys("ctrl+a", selectAll);  // TODO: Implement selectAll
+  useHotkeys("ctrl+z, meta+z", () => undo(), {
+    preventDefault: true,
+  });
+
+  useHotkeys("ctrl+y, ctrl+shift+z, meta+y, meta+shift+z", () => redo(), {
+    preventDefault: true,
+  });
+
+  useHotkeys("ctrl+a, meta+a", () => selectAll(), {
+    preventDefault: true,
+  });
   return <></>;
 }

--- a/src/components/Hotkeys.tsx
+++ b/src/components/Hotkeys.tsx
@@ -12,7 +12,7 @@ export default function (): JSX.Element {
   const { refInput } = useStoreEphemeral();
   const { machineState, executeAction } = useStoreMachine();
   const { copyNodes, pasteNodes, cutNodes, selectAll } = useStoreClipboard();
-  const { undo, redo } = useStoreFlowchart();
+  const { undo, redo } = useStoreFlowchart((s) => ({ undo: s.undo, redo: s.redo }));
   const { getNodes } = useReactFlow();
 
   for (const { actionId, hotkey, enabledStatuses } of actions) {

--- a/src/store/useStoreClipboard.ts
+++ b/src/store/useStoreClipboard.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { Edge, Node } from "reactflow";
 import { create } from "zustand";
 
-import { NodeData } from "./useStoreFlowchart";
+import { Flowchart, NodeData } from "./useStoreFlowchart";
 import useStoreFlowchart, { getNextAvailableNodeId } from "./useStoreFlowchart";
 
 interface StoreClipboard {
@@ -10,6 +10,7 @@ interface StoreClipboard {
   copyNodes: (ids: string[]) => void;
   pasteNodes: () => void;
   cutNodes: (ids: string[]) => void;
+  selectAll: () => void;
 }
 
 const useStoreClipboard = create<StoreClipboard>()((set, get) => ({
@@ -31,7 +32,8 @@ const useStoreClipboard = create<StoreClipboard>()((set, get) => ({
     const { clipboard } = get();
     if (clipboard.nodes.length === 0) return;
 
-    const { flowchart } = useStoreFlowchart.getState();
+    const { flowchart, history } = useStoreFlowchart.getState();
+    const newHistory: Flowchart[] = [...history, _.cloneDeep(flowchart)].slice(-50);
 
     // Reserva IDs novos sequencialmente sem colidir entre si
     const idMap = new Map<string, string>();
@@ -68,14 +70,23 @@ const useStoreClipboard = create<StoreClipboard>()((set, get) => ({
       ...newEdges,
     ];
 
-    useStoreFlowchart.setState({ flowchart });
+    useStoreFlowchart.setState({ flowchart, history: newHistory, future: [] });
   },
 
   cutNodes: (ids) => {
     const { copyNodes } = get();
-    const { deleteNode } = useStoreFlowchart.getState();
+    const { deleteNode, batchHistory } = useStoreFlowchart.getState();
     copyNodes(ids);
-    ids.forEach((id) => deleteNode(id));
+    batchHistory(() => {
+      ids.forEach((id) => deleteNode(id));
+    });
+  },
+
+  selectAll: () => {
+    const { flowchart } = useStoreFlowchart.getState();
+    flowchart.nodes = flowchart.nodes.map((n) => ({ ...n, selected: true }));
+    flowchart.edges = flowchart.edges.map((e) => ({ ...e, selected: true }));
+    useStoreFlowchart.setState({ flowchart });
   },
 }));
 

--- a/src/store/useStoreFlowchart.ts
+++ b/src/store/useStoreFlowchart.ts
@@ -94,6 +94,27 @@ const useStoreFlowchart = create<StoreFlowchart>()(
       let historyBatchDepth: number = 0;
       let historyBatchSaved: boolean = false;
       let isDragging: boolean = false;
+      let removeBatchOpen: boolean = false;
+
+      const defer = (cb: () => void) => {
+        if (typeof queueMicrotask === "function") {
+          return queueMicrotask(cb);
+        }
+        Promise.resolve().then(cb);
+      };
+
+      const beginRemoveHistoryBatch = () => {
+        if (removeBatchOpen) return;
+        removeBatchOpen = true;
+        historyBatchDepth++;
+        historyBatchSaved = false;
+
+        defer(() => {
+          historyBatchDepth--;
+          if (!historyBatchDepth) historyBatchSaved = false;
+          removeBatchOpen = false;
+        });
+      };
 
       const saveHistory = () => {
         if (historyBatchDepth > 0) {
@@ -167,13 +188,21 @@ const useStoreFlowchart = create<StoreFlowchart>()(
           }
           if (dragEnding) isDragging = false;
         }
-        if (hasRemove) saveHistory();
+        if (hasRemove) {
+          beginRemoveHistoryBatch();
+          saveHistory();
+        }
 
         const { flowchart } = get();
         flowchart.nodes = applyNodeChanges(changes, flowchart.nodes);
         set({ flowchart });
       },
       onEdgesChange: (changes) => {
+        if (changes.some((c) => c.type === "remove")) {
+          beginRemoveHistoryBatch();
+          saveHistory();
+        }
+
         const { flowchart } = get();
         flowchart.edges = applyEdgeChanges(changes, flowchart.edges);
         set({ flowchart });
@@ -277,8 +306,9 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       reorderVariables: (fromIndex, toIndex) => {
-        saveHistory();
         if (toIndex === undefined || fromIndex === toIndex) return;
+        saveHistory();
+        
         const { flowchart } = get();
         const variable = flowchart.variables[fromIndex];
         flowchart.variables.splice(fromIndex, 1);
@@ -293,6 +323,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
           fn();
         } finally {
           historyBatchDepth--;
+          if (!historyBatchDepth) historyBatchSaved = false;
         }
       },
       undo: () => {

--- a/src/store/useStoreFlowchart.ts
+++ b/src/store/useStoreFlowchart.ts
@@ -53,6 +53,11 @@ interface StoreFlowchart {
   changeVariableType: (id: string, type: DataType) => void;
   reorderVariables: (fromIndex: number, toIndex: number | undefined) => void;
   setSavedViewport: (viewport: Viewport) => void;
+  history: Flowchart[];
+  future: Flowchart[];
+  undo: () => void;
+  redo: () => void;
+  batchHistory: (fn: () => void) => void;
 }
 
 export function getNextAvailableNodeId(nodes: Node<NodeData>[]): string {
@@ -85,11 +90,28 @@ function getDefaultViewport(): Viewport {
 
 const useStoreFlowchart = create<StoreFlowchart>()(
   persist(
-    (set, get) => ({
-      flowchart: getDefaultFlowchart(),
-      savedViewport: getDefaultViewport(),
+    (set, get) => {
+      let historyBatchDepth: number = 0;
+      let historyBatchSaved: boolean = false;
+      let isDragging: boolean = false;
 
-      clearFlowchart: () => {
+      const saveHistory = () => {
+        if (historyBatchDepth > 0) {
+          if (historyBatchSaved) return;
+          historyBatchSaved = true;
+        }
+        const { flowchart, history } = get();
+        const newHistory = [...history, _.cloneDeep(flowchart)].slice(-50);
+        set({ history: newHistory, future: [] });
+      };
+
+      return {
+        flowchart: getDefaultFlowchart(),
+        savedViewport: getDefaultViewport(),
+        history: [],
+        future: [],
+
+        clearFlowchart: () => {
         set({
           flowchart: getDefaultFlowchart(),
           savedViewport: getDefaultViewport(),
@@ -126,6 +148,27 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       onNodesChange: (changes) => {
+        const hasRemove = changes.some((c) => c.type === "remove");
+        const hasPosition = changes.some(
+          (c) => c.type === "position" && c.dragging !== undefined
+        );
+
+        if (hasPosition) {
+          const dragStarting = changes.some(
+            (c) => c.type === "position" && c.dragging === true
+          );
+          const dragEnding = changes.some(
+            (c) => c.type === "position" && c.dragging === false
+          );
+
+          if (dragStarting && !isDragging) {
+            isDragging = true;
+            saveHistory();
+          }
+          if (dragEnding) isDragging = false;
+        }
+        if (hasRemove) saveHistory();
+
         const { flowchart } = get();
         flowchart.nodes = applyNodeChanges(changes, flowchart.nodes);
         set({ flowchart });
@@ -136,6 +179,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       addNode: (role, position) => {
+        saveHistory();
         const { flowchart } = get();
         const handles = getRoleHandles(role);
         const newNode = {
@@ -154,6 +198,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       deleteNode: (id) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.nodes = _.filter(flowchart.nodes, (node) => node.id !== id);
         flowchart.edges = _.filter(
@@ -163,6 +208,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       changeNodePayload: (id, value) => {
+        saveHistory();
         const { flowchart } = get();
         const node = _.find(flowchart.nodes, { id });
         assert(node !== undefined);
@@ -170,6 +216,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       addEdge: (connection) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.edges = _.reject(
           flowchart.edges,
@@ -181,6 +228,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       moveHandle: (connection) => {
+        saveHistory();
         const { flowchart } = get();
         const id = connection.source as string;
         const handle = connection.sourceHandle as Position;
@@ -191,6 +239,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       addVariable: () => {
+        saveHistory();
         const { flowchart } = get();
         const id = getNextAvailableVariableId(flowchart.variables);
         flowchart.variables = [
@@ -200,11 +249,13 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       removeVariable: (id) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.variables = _.reject(flowchart.variables, { id });
         set({ flowchart });
       },
       renameVariable: (id, newId) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.variables = _.map(flowchart.variables, (variable) => {
           if (variable.id === id) {
@@ -215,6 +266,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       changeVariableType: (id, type) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.variables = _.map(flowchart.variables, (variable) => {
           if (variable.id === id) {
@@ -225,6 +277,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       reorderVariables: (fromIndex, toIndex) => {
+        saveHistory();
         if (toIndex === undefined || fromIndex === toIndex) return;
         const { flowchart } = get();
         const variable = flowchart.variables[fromIndex];
@@ -233,7 +286,45 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       setSavedViewport: (viewport) => set({ savedViewport: viewport }),
-    }),
+      batchHistory: (fn: () => void) => {
+        historyBatchDepth++;
+        historyBatchSaved = false;
+        try {
+          fn();
+        } finally {
+          historyBatchDepth--;
+        }
+      },
+      undo: () => {
+        const { flowchart, history, future } = get();
+        if (history.length == 0) return;
+
+        const previousState = history[history.length - 1];
+        const newHistory = history.slice(0, -1);
+        const newFuture = [_.cloneDeep(flowchart), ...future];
+
+        set({
+          flowchart: _.cloneDeep(previousState),
+          history: newHistory,
+          future: newFuture,
+        });
+      },
+      redo: () => {
+        const { flowchart, history, future } = get();
+        if (future.length == 0) return;
+
+        const nextState = future[0];
+        const newFuture = future.slice(1);
+        const newHistory = [...history, _.cloneDeep(flowchart)];
+
+        set({
+          flowchart: _.cloneDeep(nextState),
+          history: newHistory,
+          future: newFuture,
+        });
+      },
+      };
+    },
     {
       name: "fluxolab_flow",
       version: 8,


### PR DESCRIPTION
## feat: Desfazer, Refazer e Selecionar Tudo

### Resumo

Funcionalidade de desfazer/refazer usando histórico de alteração nos Nodes (únicos ou em grupo), além da função de selecionar todos os Nodes.

### Alterações

#### `useStoreFlowchart.ts`
- **Sistema de Undo/Redo:** Adicionados os arrays `history` e `future` à store do fluxograma, limitados a 50 entradas. `undo()` restaura o último snapshot e empurra o estado atual para `future`; `redo()` faz o inverso.
- **`saveHistory()`:** Função interna que salva um snapshot do fluxograma atual antes de qualquer mutação — chamada por `addNode`, `deleteNode`, `changeNodePayload`, `addEdge`, `moveHandle`, `addVariable`, `removeVariable`, `renameVariable`, `changeVariableType` e `reorderVariables`.
- **Rastreamento de arrasto em `onNodesChange`:** Detecta mudanças de posição com `dragging: true` / `dragging: false` para salvar o histórico **uma única vez** no início do gesto de arrasto — assim, arrastar um grupo de nodes gera apenas uma entrada de undo.
- **Rastreamento de remoção em `onNodesChange`:** Salva o histórico antes de aplicar mudanças do tipo `remove` (ex: pressionar Delete numa seleção), garantindo que deleções em grupo pelo ReactFlow sejam desfeitas em um único passo.
- **`batchHistory(fn)`:** Envolve múltiplas mutações para que apenas a **primeira** chamada de `saveHistory()` dentro do lote realmente salve um snapshot. Isso evita que operações com múltiplos nós (como recortar) criem várias entradas de undo.

#### `useStoreClipboard.ts`
- **Colar com suporte a undo:** `pasteNodes()` agora salva um snapshot do histórico antes de modificar o fluxograma, tornando a operação de colar desfeita em um passo.
- **Recortar com histórico em lote:** `cutNodes()` envolve seu loop de `deleteNode` dentro de `batchHistory()`, para que recortar múltiplos nodes crie apenas uma entrada de undo.
- **Selecionar Tudo:** Adicionado `selectAll()` que marca todos os nodes e edges como `selected: true`.

#### `Hotkeys.tsx`
- Atalhos de teclado registrados:
  - `Ctrl+Z` / `⌘+Z` → Desfazer
  - `Ctrl+Y` / `Ctrl+Shift+Z` / `⌘+Shift+Z` → Refazer
  - `Ctrl+A` / `⌘+A` → Selecionar Tudo

### Arquivos modificados
- `src/store/useStoreFlowchart.ts`
- `src/store/useStoreClipboard.ts`
- `src/components/Hotkeys.tsx`