### PR TITLE
feat: Undo and Redo methods

### DIFF
--- a/src/components/Hotkeys.tsx
+++ b/src/components/Hotkeys.tsx
@@ -7,6 +7,7 @@ import actions from "~/core/actions";
 import useStoreClipboard from "~/store/useStoreClipboard";
 import useStoreEphemeral from "~/store/useStoreEphemeral";
 import useStoreMachine from "~/store/useStoreMachine";
+import { redo, undo } from "~/store/useStoreHistory";
 
 export default function (): JSX.Element {
   const { refInput } = useStoreEphemeral();
@@ -77,6 +78,16 @@ export default function (): JSX.Element {
     },
     { preventDefault: true },
   );
+
+  // Undo
+  useHotkeys("ctrl+z, meta+z", () => undo(), {
+      preventDefault: true,
+  });
+
+  // Redo
+  useHotkeys("ctrl+y, ctrl+shift+z, meta+y, meta+shift+z", () => redo(), {
+      preventDefault: true,
+  });
 
   return <></>;
 }

--- a/src/store/useStoreFlowchart.ts
+++ b/src/store/useStoreFlowchart.ts
@@ -18,6 +18,7 @@ import { persist } from "zustand/middleware";
 import { DataType } from "~/core/dataTypes";
 import { Role, getRoleHandles } from "~/core/roles";
 import assert from "~/utils/assert";
+import { beginRemoveHistoryBatch, handleChanges, saveHistory } from "./useStoreHistory";
 
 import { SimpleFlowchart } from "./serialize";
 
@@ -34,9 +35,11 @@ export interface Flowchart {
   edges: Edge[];
 }
 
-interface StoreFlowchart {
+export interface StoreFlowchart {
   flowchart: Flowchart;
   savedViewport: Viewport;
+  history: Flowchart[];
+  future: Flowchart[];
   clearFlowchart: () => void;
   importSimpleFlowchart: (simpleFlowchart: SimpleFlowchart) => void;
   setTitle: (title: string) => void;
@@ -88,6 +91,8 @@ const useStoreFlowchart = create<StoreFlowchart>()(
     (set, get) => ({
       flowchart: getDefaultFlowchart(),
       savedViewport: getDefaultViewport(),
+      history: [],
+      future: [],
 
       clearFlowchart: () => {
         set({
@@ -126,16 +131,22 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       onNodesChange: (changes) => {
+        handleChanges(changes);
         const { flowchart } = get();
         flowchart.nodes = applyNodeChanges(changes, flowchart.nodes);
         set({ flowchart });
       },
       onEdgesChange: (changes) => {
+        if (changes.some((c) => c.type === "remove")) {
+            beginRemoveHistoryBatch();
+            saveHistory();
+        }
         const { flowchart } = get();
         flowchart.edges = applyEdgeChanges(changes, flowchart.edges);
         set({ flowchart });
       },
       addNode: (role, position) => {
+        saveHistory();
         const { flowchart } = get();
         const handles = getRoleHandles(role);
         const newNode = {
@@ -154,6 +165,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       deleteNode: (id) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.nodes = _.filter(flowchart.nodes, (node) => node.id !== id);
         flowchart.edges = _.filter(
@@ -163,6 +175,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       changeNodePayload: (id, value) => {
+        saveHistory();
         const { flowchart } = get();
         const node = _.find(flowchart.nodes, { id });
         assert(node !== undefined);
@@ -170,6 +183,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       addEdge: (connection) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.edges = _.reject(
           flowchart.edges,
@@ -181,6 +195,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       moveHandle: (connection) => {
+        saveHistory();
         const { flowchart } = get();
         const id = connection.source as string;
         const handle = connection.sourceHandle as Position;
@@ -191,6 +206,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       addVariable: () => {
+        saveHistory();
         const { flowchart } = get();
         const id = getNextAvailableVariableId(flowchart.variables);
         flowchart.variables = [
@@ -200,11 +216,13 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       removeVariable: (id) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.variables = _.reject(flowchart.variables, { id });
         set({ flowchart });
       },
       renameVariable: (id, newId) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.variables = _.map(flowchart.variables, (variable) => {
           if (variable.id === id) {
@@ -215,6 +233,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
         set({ flowchart });
       },
       changeVariableType: (id, type) => {
+        saveHistory();
         const { flowchart } = get();
         flowchart.variables = _.map(flowchart.variables, (variable) => {
           if (variable.id === id) {
@@ -226,6 +245,7 @@ const useStoreFlowchart = create<StoreFlowchart>()(
       },
       reorderVariables: (fromIndex, toIndex) => {
         if (toIndex === undefined || fromIndex === toIndex) return;
+        saveHistory();
         const { flowchart } = get();
         const variable = flowchart.variables[fromIndex];
         flowchart.variables.splice(fromIndex, 1);

--- a/src/store/useStoreHistory.ts
+++ b/src/store/useStoreHistory.ts
@@ -1,0 +1,92 @@
+import UseStoreFlowchart from "./useStoreFlowchart";
+import _ from "lodash";
+import { NodeChange } from "reactflow";
+
+let historyBatchDepth: number = 0;
+let historyBatchSaved: boolean = false;
+let isDragging: boolean = false;
+let removeBatchOpen: boolean = false;
+
+const defer = (cb: () => void) => {
+    if (typeof queueMicrotask === "function") return queueMicrotask(cb);
+    Promise.resolve().then(cb);
+};
+
+export function beginRemoveHistoryBatch() {
+    if (removeBatchOpen) return;
+    removeBatchOpen = true;
+    historyBatchDepth++;
+    historyBatchSaved = false;
+
+    defer(() => {
+        historyBatchDepth--;
+        if (!historyBatchDepth) historyBatchSaved = false;
+        removeBatchOpen = false;
+    });
+}
+
+export function saveHistory() {
+    if (historyBatchDepth > 0) {
+        if (historyBatchSaved) return;
+        historyBatchSaved = true;
+    }
+    const { flowchart, history } = UseStoreFlowchart.getState();
+    const newHistory = [...history, _.cloneDeep(flowchart)].slice(-30);
+    UseStoreFlowchart.setState({ history: newHistory, future: [] });
+}
+
+export function handleChanges(changes: NodeChange[]) {
+    const hasRemove = changes.some((c) => c.type === "remove");
+    const hasPosition = changes.some(
+        (c) => c.type === "position" && c.dragging !== undefined
+    );
+
+    if (hasPosition) {
+        const dragStarting = changes.some(
+            (c) => c.type === "position" && c.dragging === true
+        );
+        const dragEnding = changes.some(
+            (c) => c.type === "position" && c.dragging === false
+        );
+
+        if (dragStarting && !isDragging) {
+            isDragging = true;
+            saveHistory();
+        }
+        if (dragEnding) isDragging = false;
+    }
+    if (hasRemove) {
+        beginRemoveHistoryBatch();
+        saveHistory();
+    }
+}
+
+export function undo() {
+    const { flowchart, history, future } = UseStoreFlowchart.getState();
+    if (history.length == 0) return;
+
+    const previousState = history[history.length - 1];
+    const newHistory = history.slice(0, -1);
+    const newFuture = [_.cloneDeep(flowchart), ...future];
+
+    UseStoreFlowchart.setState({
+        flowchart: _.cloneDeep(previousState),
+        history: newHistory,
+        future: newFuture,
+    });
+}
+
+export function redo() {
+    const { flowchart, history, future } = UseStoreFlowchart.getState();
+    if (future.length == 0) return;
+
+    const nextState = future[0];
+    const newFuture = future.slice(1);
+    const newHistory = [...history, _.cloneDeep(flowchart)];
+
+    UseStoreFlowchart.setState({
+        flowchart: _.cloneDeep(nextState),
+        history: newHistory,
+        future: newFuture,
+    });
+}


### PR DESCRIPTION
Adicionei todas as funções relacionadas no arquivo useStoreHistory.
No arquivo useStoreFlowchart, apenas adicionei os métodos em cada uma das alterações de node. 
No arquivo Hotkeys, criei a keybind para ctrl+z e ctrl+shift+z/ctrl+y, usando os métodos que estão no useStoreHistory.

A lógica é a mesma do pr anterior, apenas reorganizei tudo em um único arquivo.

O history salva alterações de node como add, delete e drag, assim como as váriaveis (add, delete e rename).